### PR TITLE
Make timestamp for temporary directories customisable

### DIFF
--- a/fotosort/__init__.py
+++ b/fotosort/__init__.py
@@ -19,16 +19,19 @@ def run():
 
     confpath = os.path.join(appdirs.user_config_dir(), "fotosort.yaml")
 
+    conf_dict = {
+        "copy_pictures": False,
+        "extensions": ['*.jpg', '*.JPG', '*.png', '*.PNG'],
+        "perm_output_dirs": [],
+        "timestamp_prefix_format": "%Y_%m_%d",
+        "temp_output_prefix": os.path.expanduser('~')
+    }
+
     if os.path.isfile(confpath):
         with open(confpath) as stream:
-            conf = SimpleNamespace(**yaml.safe_load(stream))
-    else:
-        conf = SimpleNamespace(
-            copy_pictures=False,
-            extensions=['*.jpg', '*.JPG', '*.png', '*.PNG'],
-            perm_output_dirs=[],
-            temp_output_prefix=os.path.expanduser('~')
-        )
+            conf_dict.update(yaml.safe_load(stream))
+
+    conf = SimpleNamespace(**conf_dict)
 
     controller = Controller(conf, args.location)
     ui = UI(conf, controller)

--- a/fotosort/imgutils.py
+++ b/fotosort/imgutils.py
@@ -1,6 +1,7 @@
 # From https://stackoverflow.com/questions/13872331/rotating-an-image-with-orientation-specified-in-exif-using-python-without-pil-in
 
 from PIL import Image, ExifTags
+import datetime
 
 
 # This remains from before QML auto-rotated the picture and is not used any longer
@@ -33,6 +34,6 @@ def get_timestamp(filepath):
         if exifdata is None:
             return ''
         s = exifdata[36867]
-        return s.replace(':', '_').replace(' ', '-')
-    except (AttributeError, KeyError, IndexError):
+        return datetime.datetime.strptime(s, '%Y:%m:%d %H:%M:%S')
+    except (AttributeError, KeyError, IndexError, ValueError):
         return ''

--- a/fotosort/ui.py
+++ b/fotosort/ui.py
@@ -17,6 +17,7 @@ class UI(QObject):
         self.conf = conf
         self.temp_output_dirs = []
         self.output_dirs = self.conf.perm_output_dirs.copy()
+        self.timestamp_prefix_format = self.conf.timestamp_prefix_format
 
         self.app = QApplication([])
         self.engine = QQmlApplicationEngine()
@@ -66,7 +67,10 @@ class UI(QObject):
 
     @Slot(result=str)
     def getCurrentImageTimestamp(self):
-        return imgutils.get_timestamp(self.currentImage)
+        ts = imgutils.get_timestamp(self.currentImage)
+        if ts:
+            return ts.strftime('%Y_%m_%d-%H_%M_%S')
+        return ""
 
     def setCurrentImage(self, new_image):
         self.currentImage = new_image
@@ -146,9 +150,10 @@ class UI(QObject):
     @Slot()
     def openAddTempTargetDialog(self):
         ts = imgutils.get_timestamp(self.controller.current())
+        ts_str = ""
         if ts:
-            ts = self.conf.temp_output_prefix + ts[:10] + ' '
-        self.root.openAddTempTargetDialog(ts)
+            ts_str = ts.strftime(self.timestamp_prefix_format)
+        self.root.openAddTempTargetDialog(ts_str)
 
     @Slot(str)
     def applyAddTempTargetDialog(self, newTarget):


### PR DESCRIPTION
When creating temporary directories, the timestamp (date) of the current image is automatically suggested as a prefix for the directory name. The format of the timestamp is hardcoded.

I would like to use a different format for this timestamp. This PR makes the timestamp configurable. The user can configure a format string that is interpreted by strftime, directly in the config file.

The default format string yields the same result as the previous hardcoded variant. The configuration loading logic was updated to support seamless migration from old config files, where no timestamp format was specified.

I have not yet bothered to add this new config option to the settings dialog; let me know if you consider that a hard requirement.