### PR TITLE
Fix autocomplete sometimes completing to completely wrong completions

### DIFF
--- a/fotosort/ui.py
+++ b/fotosort/ui.py
@@ -49,6 +49,12 @@ class UI(QObject):
         if len(searchtext) == 0:
             return ""
         for item in self.output_dirs:
+            if searchtext == item:
+                return item
+        for item in self.output_dirs:
+            if item.startswith(searchtext):
+                return item
+        for item in self.output_dirs:
             if searchtext in item:
                 return item
         for item in self.output_dirs:  # Fallback to lowercase search


### PR DESCRIPTION
If I have a target "me" and a target "games", I cannot select the "me" target at all, since it autocompletes to "games". Even if I select it from the drop-down, the autocomplete logic still applies and yields "games".

To fix this, I extended the autocomplete logic:
* Exact matches are always checked first. *An exact match should always have precedence over everything else.*
* Prefix matches are checked next. *"gam" should match "games" over "boardgames".*
* Infix matches are checked next.
* Finally, lowercase infix matches are checked as the final fallback.
